### PR TITLE
Add edit command

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -60,6 +60,7 @@ func New(cfg *config.Config, dal *data.DAL, gh *github.API, log *log.Entry) *Bot
 	b.commands = map[string]*cmd.Command{
 		"help":         NewHelpCmd(b.help),
 		"set":          NewSetCmd(b.set),
+		"edit":         NewEditUserCmd(b.editUser),
 		"view-user":    NewViewUserCmd(b.viewUser),
 		"view-team":    NewViewTeamCmd(b.viewTeam),
 		"add-user":     NewAddUserCmd(b.addUser),

--- a/bot/edit_user.go
+++ b/bot/edit_user.go
@@ -60,7 +60,10 @@ func (b *Bot) editUser(c cmd.Context) (string, slack.PostMessageParameters) {
 
 	c.User = model.Member{
 		SlackID: parseMention(c.Args[0].Value),
-		IsAdmin: false,
 	}
-	return b.set(c)
+	if err := b.dal.GetMemberBySlackID(&c.User); err != nil {
+		return "Failed to find member " + c.Args[0].Value, noParams
+	}
+	_, params := b.set(c)
+	return c.Args[0].Value + "'s information has been updated", params
 }

--- a/bot/edit_user.go
+++ b/bot/edit_user.go
@@ -1,0 +1,66 @@
+package bot
+
+import (
+	"github.com/nlopes/slack"
+	"github.com/ubclaunchpad/rocket/cmd"
+	"github.com/ubclaunchpad/rocket/model"
+)
+
+// NewEditUserCmd returns an edit user command that allows admins to edit other
+// users' info
+func NewEditUserCmd(ch cmd.CommandHandler) *cmd.Command {
+	return &cmd.Command{
+		Name:     "edit",
+		HelpText: "Set properties on another user's Launch Pad profile (admins only)",
+		Options: map[string]*cmd.Option{
+			"name": &cmd.Option{
+				Key:      "name",
+				HelpText: "user's full name",
+				Format:   nameRegex,
+			},
+			"email": &cmd.Option{
+				Key:      "email",
+				HelpText: "user's email address",
+				Format:   emailRegex,
+			},
+			"position": &cmd.Option{
+				Key:      "position",
+				HelpText: "user's creative Launch Pad title",
+				Format:   anyRegex,
+			},
+			"github": &cmd.Option{
+				Key:      "github",
+				HelpText: "user's Github username",
+				Format:   anyRegex,
+			},
+			"major": &cmd.Option{
+				Key:      "major",
+				HelpText: "user's major at UBC",
+				Format:   anyRegex,
+			},
+		},
+		Args: []cmd.Argument{
+			cmd.Argument{
+				Name:      "member",
+				HelpText:  "the Slack handle of the user to edit",
+				Format:    anyRegex,
+				MultiWord: false,
+			},
+		},
+		HandleFunc: ch,
+	}
+}
+
+// Generic command for setting some information about the sender's profile.
+func (b *Bot) editUser(c cmd.Context) (string, slack.PostMessageParameters) {
+	noParams := slack.PostMessageParameters{}
+	if !c.User.IsAdmin {
+		return "You must be an admin to use this command", noParams
+	}
+
+	c.User = model.Member{
+		SlackID: parseMention(c.Args[0].Value),
+		IsAdmin: false,
+	}
+	return b.set(c)
+}

--- a/bot/remove_admin.go
+++ b/bot/remove_admin.go
@@ -28,11 +28,10 @@ func NewRemoveAdminCmd(ch cmd.CommandHandler) *cmd.Command {
 
 // removeAdmin removes admin priveledges from an existing user.
 func (b *Bot) removeAdmin(c cmd.Context) (string, slack.PostMessageParameters) {
+	noParams := slack.PostMessageParameters{}
 	if !c.User.IsAdmin {
 		return "You must be an admin to use this command", noParams
 	}
-
-	noParams := slack.PostMessageParameters{}
 	user := model.Member{
 		SlackID: parseMention(c.Args[0].Value),
 		IsAdmin: false,


### PR DESCRIPTION
This command is just like the `set` command, only it allows one to edit another user's info, and is only available to admins.