### PR TITLE
Bio char limit

### DIFF
--- a/bot/set.go
+++ b/bot/set.go
@@ -41,7 +41,7 @@ func NewSetCmd(ch cmd.CommandHandler) *cmd.Command {
 			},
 			"biography": &cmd.Option{
 				Key:      "biography",
-				HelpText: "a little bit about yourself",
+				HelpText: "a little bit about yourself (600 characters max)",
 				Format:   anyRegex,
 			},
 		},
@@ -113,6 +113,10 @@ func (b *Bot) set(c cmd.Context) (string, slack.PostMessageParameters) {
 
 	if c.Options["biography"].Value != "" {
 		c.User.Biography = c.Options["biography"].Value
+		// Max bio length is 600 characters
+		if len(c.User.Biography) > 600 {
+			return "Sorry, your biography must be at most 600 characters in length", params
+		}
 		if err := b.dal.SetMemberBiography(&c.User); err != nil {
 			log.WithError(err).Error("Failed to set biography")
 			return "Failed to set biography", params

--- a/model/member.go
+++ b/model/member.go
@@ -57,20 +57,10 @@ func (m *Member) SlackAttachments() []slack.Attachment {
 		},
 	}
 
-	if len(m.Name) == 0 {
-		attachments[0].Color = "danger"
-	}
-	if len(m.Email) == 0 {
-		attachments[1].Color = "danger"
-	}
-	if len(m.Position) == 0 {
-		attachments[2].Color = "danger"
-	}
-	if len(m.GithubUsername) == 0 {
-		attachments[3].Color = "danger"
-	}
-	if len(m.Major) == 0 {
-		attachments[4].Color = "danger"
+	for _, attachment := range attachments {
+		if len(attachment.Text) == 0 {
+			attachment.Color = "danger"
+		}
 	}
 
 	return attachments


### PR DESCRIPTION
This ensures that user biographies can't be more than 600 characters long. There's also a very minor refactor in here.