### PR TITLE
Team platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ test:
 
 docker:
 	docker-compose up -d
+
+build:
+	docker-compose up -d --build rocket

--- a/bot/add_admin.go
+++ b/bot/add_admin.go
@@ -13,13 +13,12 @@ func NewAddAdminCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "add-admin",
 		HelpText: "Make an existing user an admin (admins only)",
-		Options:  map[string]*cmd.Option{},
-		Args: []cmd.Argument{
-			cmd.Argument{
-				Name:      "username",
-				HelpText:  "the Slack handle of the user to make an admin",
-				Format:    anyRegex,
-				MultiWord: false,
+		Options: map[string]*cmd.Option{
+			"user": &cmd.Option{
+				Key:      "user",
+				HelpText: "the Slack handle of the user to make an admin",
+				Format:   anyRegex,
+				Required: true,
 			},
 		},
 		HandleFunc: ch,
@@ -33,13 +32,14 @@ func (b *Bot) addAdmin(c cmd.Context) (string, slack.PostMessageParameters) {
 	}
 
 	noParams := slack.PostMessageParameters{}
-	user := model.Member{
-		SlackID: parseMention(c.Args[0].Value),
+	username := c.Options["user"].Value
+	member := model.Member{
+		SlackID: parseMention(username),
 		IsAdmin: true,
 	}
-	if err := b.dal.SetMemberIsAdmin(&user); err != nil {
-		log.WithError(err).Error("Failed to make user " + c.Args[0].Value + " admin")
+	if err := b.dal.SetMemberIsAdmin(&member); err != nil {
+		log.WithError(err).Error("Failed to make user " + username + " admin")
 		return "Failed to make user admin", noParams
 	}
-	return toMention(user.SlackID) + " has been made an admin :tada:", noParams
+	return toMention(member.SlackID) + " has been made an admin :tada:", noParams
 }

--- a/bot/add_team.go
+++ b/bot/add_team.go
@@ -14,13 +14,18 @@ func NewAddTeamCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "add-team",
 		HelpText: "Create a new Launch Pad team",
-		Options:  map[string]*cmd.Option{},
-		Args: []cmd.Argument{
-			cmd.Argument{
-				Name:      "team-name",
-				HelpText:  "the name of the new team",
-				Format:    anyRegex,
-				MultiWord: true,
+		Options: map[string]*cmd.Option{
+			"name": &cmd.Option{
+				Key:      "name",
+				HelpText: "the name of the new team",
+				Format:   anyRegex,
+				Required: true,
+			},
+			"platform": &cmd.Option{
+				Key:      "platform",
+				HelpText: "the platform the team develops on (i.e iOS, Android etc)",
+				Format:   anyRegex,
+				Required: true,
 			},
 		},
 		HandleFunc: ch,
@@ -35,7 +40,8 @@ func (b *Bot) addTeam(c cmd.Context) (string, slack.PostMessageParameters) {
 		return "You must be an admin to use this command", noParams
 	}
 
-	teamName := c.Args[0].Value
+	teamName := c.Options["name"].Value
+	platform := c.Options["platform"].Value
 	// teamName = "Great Team", ghTeamName = "great-team"
 	ghTeamName := strings.ToLower(strings.Replace(teamName, " ", "-", -1))
 
@@ -49,6 +55,7 @@ func (b *Bot) addTeam(c cmd.Context) (string, slack.PostMessageParameters) {
 
 	team := model.Team{
 		Name:         teamName,
+		Platform:     platform,
 		GithubTeamID: int(*ghTeam.ID),
 	}
 	// Finally, add team to DB
@@ -56,5 +63,6 @@ func (b *Bot) addTeam(c cmd.Context) (string, slack.PostMessageParameters) {
 		log.WithError(err).Errorf("Failed to create team %s", team.Name)
 		return "Failed to create team " + team.Name, noParams
 	}
+
 	return "`" + team.Name + "` has been added :tada:", noParams
 }

--- a/bot/add_user.go
+++ b/bot/add_user.go
@@ -14,19 +14,18 @@ func NewAddUserCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "add-user",
 		HelpText: "Add a user to a team",
-		Options:  map[string]*cmd.Option{},
-		Args: []cmd.Argument{
-			cmd.Argument{
-				Name:      "member",
-				HelpText:  "the Slack handle of the user to add to a team",
-				Format:    anyRegex,
-				MultiWord: false,
+		Options: map[string]*cmd.Option{
+			"user": &cmd.Option{
+				Key:      "user",
+				HelpText: "the Slack handle of the user to add to a team",
+				Format:   anyRegex,
+				Required: true,
 			},
-			cmd.Argument{
-				Name:      "team-name",
-				HelpText:  "the team to add the user to",
-				Format:    anyRegex,
-				MultiWord: true,
+			"team": &cmd.Option{
+				Key:      "team",
+				HelpText: "the team to add the user to",
+				Format:   anyRegex,
+				Required: true,
 			},
 		},
 		HandleFunc: ch,
@@ -36,34 +35,36 @@ func NewAddUserCmd(ch cmd.CommandHandler) *cmd.Command {
 // addUser adds an existing user to a team.
 func (b *Bot) addUser(c cmd.Context) (string, slack.PostMessageParameters) {
 	noParams := slack.PostMessageParameters{}
+	username := c.Options["user"].Value
+	teamName := c.Options["team"].Value
 
 	if !c.User.IsAdmin {
 		return "You must be an admin to use this command", noParams
 	}
 
 	team := model.Team{
-		Name: c.Args[1].Value,
+		Name: teamName,
 	}
 	if err := b.dal.GetTeamByName(&team); err != nil {
 		log.WithError(err).Error("Failed to find team " + team.Name)
 		return "Failed to find team " + team.Name, noParams
 	}
 
-	slackID := parseMention(c.Args[0].Value)
+	slackID := parseMention(username)
 	member := model.Member{
 		SlackID: slackID,
 	}
 	if err := b.dal.GetMemberBySlackID(&member); err != nil {
-		log.WithError(err).Errorf("Failed to find member %s", c.Args[0].Value)
-		return "Failed to find member " + c.Args[0].Value, noParams
+		log.WithError(err).Errorf("Failed to find member %s", username)
+		return "Failed to find member " + username, noParams
 	}
 
 	// Add user to corresponding GitHub team
 	if err := b.gh.AddUserToTeam(member.GithubUsername, team.GithubTeamID); err != nil {
 		log.WithError(err).Errorf("Failed to add user %s to GitHub team %s",
-			c.Args[0].Value, team.Name)
+			member.Name, team.Name)
 		return fmt.Sprintf("Failed to add user %s to GitHub team %s",
-			c.Args[0].Value, team.Name), noParams
+			member.Name, team.Name), noParams
 	}
 
 	teamMember := model.TeamMember{
@@ -73,9 +74,9 @@ func (b *Bot) addUser(c cmd.Context) (string, slack.PostMessageParameters) {
 	// Finally, add relation to DB
 	if err := b.dal.CreateTeamMember(&teamMember); err != nil {
 		log.WithError(err).Errorf("Failed to add member %s to team %s",
-			c.Args[0].Value, team.Name)
+			member.Name, team.Name)
 		return fmt.Sprintf("Failed to add member %s to team %s",
-			c.Args[0].Value, team.Name), noParams
+			member.Name, team.Name), noParams
 	}
 	return toMention(member.SlackID) +
 		" was added to `" + team.Name + "` team :tada:", noParams

--- a/bot/commands_test.go
+++ b/bot/commands_test.go
@@ -55,7 +55,7 @@ func TestHelp(t *testing.T) {
 func TestHelpWithCommand(t *testing.T) {
 	b := getTestBot()
 	for _, cmd := range b.commands {
-		text := "@rocket help --command=`" + cmd.Name + "`"
+		text := "@rocket help command=`" + cmd.Name + "`"
 		ctx := getTestContext(text)
 		res, _, err := b.commands["help"].Execute(ctx)
 		t.Log(res)
@@ -65,7 +65,7 @@ func TestHelpWithCommand(t *testing.T) {
 }
 
 func TestHelpWithInvalidCommand(t *testing.T) {
-	text := "@rocket help --command=`blabla`"
+	text := "@rocket help command=`blabla`"
 	ctx := getTestContext(text)
 	b := getTestBot()
 	res, _, err := b.commands["help"].Execute(ctx)

--- a/bot/commands_test.go
+++ b/bot/commands_test.go
@@ -55,7 +55,7 @@ func TestHelp(t *testing.T) {
 func TestHelpWithCommand(t *testing.T) {
 	b := getTestBot()
 	for _, cmd := range b.commands {
-		text := "@rocket help command=`" + cmd.Name + "`"
+		text := "@rocket help command={" + cmd.Name + "}"
 		ctx := getTestContext(text)
 		res, _, err := b.commands["help"].Execute(ctx)
 		t.Log(res)
@@ -65,7 +65,7 @@ func TestHelpWithCommand(t *testing.T) {
 }
 
 func TestHelpWithInvalidCommand(t *testing.T) {
-	text := "@rocket help command=`blabla`"
+	text := "@rocket help command={blabla}"
 	ctx := getTestContext(text)
 	b := getTestBot()
 	res, _, err := b.commands["help"].Execute(ctx)

--- a/bot/edit_user.go
+++ b/bot/edit_user.go
@@ -13,38 +13,41 @@ func NewEditUserCmd(ch cmd.CommandHandler) *cmd.Command {
 		Name:     "edit",
 		HelpText: "Set properties on another user's Launch Pad profile (admins only)",
 		Options: map[string]*cmd.Option{
+			"member": &cmd.Option{
+				Key:      "member",
+				HelpText: "the Slack handle of the user to edit",
+				Format:   anyRegex,
+				Required: false,
+			},
 			"name": &cmd.Option{
 				Key:      "name",
 				HelpText: "user's full name",
 				Format:   nameRegex,
+				Required: false,
 			},
 			"email": &cmd.Option{
 				Key:      "email",
 				HelpText: "user's email address",
 				Format:   emailRegex,
+				Required: false,
 			},
 			"position": &cmd.Option{
 				Key:      "position",
 				HelpText: "user's creative Launch Pad title",
 				Format:   anyRegex,
+				Required: false,
 			},
 			"github": &cmd.Option{
 				Key:      "github",
 				HelpText: "user's Github username",
 				Format:   anyRegex,
+				Required: false,
 			},
 			"major": &cmd.Option{
 				Key:      "major",
 				HelpText: "user's major at UBC",
 				Format:   anyRegex,
-			},
-		},
-		Args: []cmd.Argument{
-			cmd.Argument{
-				Name:      "member",
-				HelpText:  "the Slack handle of the user to edit",
-				Format:    anyRegex,
-				MultiWord: false,
+				Required: false,
 			},
 		},
 		HandleFunc: ch,
@@ -58,12 +61,13 @@ func (b *Bot) editUser(c cmd.Context) (string, slack.PostMessageParameters) {
 		return "You must be an admin to use this command", noParams
 	}
 
+	memberName := c.Options["member"].Value
 	c.User = model.Member{
-		SlackID: parseMention(c.Args[0].Value),
+		SlackID: parseMention(memberName),
 	}
 	if err := b.dal.GetMemberBySlackID(&c.User); err != nil {
-		return "Failed to find member " + c.Args[0].Value, noParams
+		return "Failed to find member " + memberName, noParams
 	}
 	_, params := b.set(c)
-	return c.Args[0].Value + "'s information has been updated", params
+	return memberName + "'s information has been updated", params
 }

--- a/bot/help.go
+++ b/bot/help.go
@@ -18,9 +18,9 @@ func NewHelpCmd(ch cmd.CommandHandler) *cmd.Command {
 				Key:      "command",
 				HelpText: "get help using a particular Rocket command",
 				Format:   alphaRegex,
+				Required: false,
 			},
 		},
-		Args:       []cmd.Argument{},
 		HandleFunc: ch,
 	}
 }
@@ -33,7 +33,8 @@ func (b *Bot) help(c cmd.Context) (string, slack.PostMessageParameters) {
 	if opt == "" {
 		// General help
 		res = "Usage: @rocket COMMAND\n\nGet help using a specific " +
-			"command with \"@rocket help --command=`COMMAND`\""
+			"command with \"@rocket help command=`COMMAND`\"\n" +
+			"Example: @rocket set name=`A Guy` github=`arealguy`"
 		cmds := ""
 		for _, cmd := range b.commands {
 			cmds += fmt.Sprintf("%s\t\t%s\n", cmd.Name, cmd.HelpText)

--- a/bot/help.go
+++ b/bot/help.go
@@ -33,8 +33,8 @@ func (b *Bot) help(c cmd.Context) (string, slack.PostMessageParameters) {
 	if opt == "" {
 		// General help
 		res = "Usage: @rocket COMMAND\n\nGet help using a specific " +
-			"command with \"@rocket help command=`COMMAND`\"\n" +
-			"Example: @rocket set name=`A Guy` github=`arealguy`"
+			"command with \"@rocket help command={COMMAND}\"\n" +
+			"Example: @rocket set name={A Guy} github={arealguy}"
 		cmds := ""
 		for _, cmd := range b.commands {
 			cmds += fmt.Sprintf("%s\t\t%s\n", cmd.Name, cmd.HelpText)

--- a/bot/refresh.go
+++ b/bot/refresh.go
@@ -14,7 +14,6 @@ func NewRefreshCmd(ch cmd.CommandHandler) *cmd.Command {
 		Name:     "refresh",
 		HelpText: "for debugging Rocket (admins only)",
 		Options:  map[string]*cmd.Option{},
-		Args:     []cmd.Argument{},
 	}
 }
 

--- a/bot/remove_admin.go
+++ b/bot/remove_admin.go
@@ -13,13 +13,12 @@ func NewRemoveAdminCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "remove-admin",
 		HelpText: "Remove admin rights from a user (admins only)",
-		Options:  map[string]*cmd.Option{},
-		Args: []cmd.Argument{
-			cmd.Argument{
-				Name:      "username",
-				HelpText:  "the Slack handle of the user to remove admin rights from",
-				Format:    anyRegex,
-				MultiWord: false,
+		Options: map[string]*cmd.Option{
+			"user": &cmd.Option{
+				Key:      "user",
+				HelpText: "the Slack handle of the user to remove admin rights from",
+				Format:   anyRegex,
+				Required: true,
 			},
 		},
 		HandleFunc: ch,
@@ -33,7 +32,7 @@ func (b *Bot) removeAdmin(c cmd.Context) (string, slack.PostMessageParameters) {
 		return "You must be an admin to use this command", noParams
 	}
 	user := model.Member{
-		SlackID: parseMention(c.Args[0].Value),
+		SlackID: parseMention(c.Options["user"].Value),
 		IsAdmin: false,
 	}
 	if err := b.dal.SetMemberIsAdmin(&user); err != nil {

--- a/bot/remove_team.go
+++ b/bot/remove_team.go
@@ -12,13 +12,12 @@ func NewRemoveTeamCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "remove-team",
 		HelpText: "Delete a new Launch Pad team",
-		Options:  map[string]*cmd.Option{},
-		Args: []cmd.Argument{
-			cmd.Argument{
-				Name:      "team-name",
-				HelpText:  "the name of the team to remove",
-				Format:    anyRegex,
-				MultiWord: true,
+		Options: map[string]*cmd.Option{
+			"team": &cmd.Option{
+				Key:      "team",
+				HelpText: "the name of the team to remove",
+				Format:   anyRegex,
+				Required: true,
 			},
 		},
 		HandleFunc: ch,
@@ -33,7 +32,7 @@ func (b *Bot) removeTeam(c cmd.Context) (string, slack.PostMessageParameters) {
 
 	noParams := slack.PostMessageParameters{}
 	team := model.Team{
-		Name: c.Args[0].Value,
+		Name: c.Options["team"].Value,
 	}
 	if err := b.dal.GetTeamByName(&team); err != nil {
 		log.WithError(err).Error("Failed to find team " + team.Name)

--- a/bot/set.go
+++ b/bot/set.go
@@ -18,34 +18,39 @@ func NewSetCmd(ch cmd.CommandHandler) *cmd.Command {
 				Key:      "name",
 				HelpText: "your full name",
 				Format:   nameRegex,
+				Required: false,
 			},
 			"email": &cmd.Option{
 				Key:      "email",
 				HelpText: "your email address",
 				Format:   emailRegex,
+				Required: false,
 			},
 			"position": &cmd.Option{
 				Key:      "position",
 				HelpText: "your creative Launch Pad title",
 				Format:   anyRegex,
+				Required: false,
 			},
 			"github": &cmd.Option{
 				Key:      "github",
 				HelpText: "your Github username",
 				Format:   anyRegex,
+				Required: false,
 			},
 			"major": &cmd.Option{
 				Key:      "major",
 				HelpText: "your major at UBC",
 				Format:   anyRegex,
+				Required: false,
 			},
 			"biography": &cmd.Option{
 				Key:      "biography",
 				HelpText: "a little bit about yourself (600 characters max)",
 				Format:   anyRegex,
+				Required: false,
 			},
 		},
-		Args:       []cmd.Argument{},
 		HandleFunc: ch,
 	}
 }

--- a/bot/teams.go
+++ b/bot/teams.go
@@ -13,7 +13,6 @@ func NewTeamsCmd(ch cmd.CommandHandler) *cmd.Command {
 		Name:       "teams",
 		HelpText:   "List Launch Pad teams",
 		Options:    map[string]*cmd.Option{},
-		Args:       []cmd.Argument{},
 		HandleFunc: ch,
 	}
 }

--- a/bot/view_team.go
+++ b/bot/view_team.go
@@ -12,13 +12,12 @@ func NewViewTeamCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "view-team",
 		HelpText: "View information about a Launch Pad team",
-		Options:  map[string]*cmd.Option{},
-		Args: []cmd.Argument{
-			cmd.Argument{
-				Name:      "team-name",
-				HelpText:  "the name of the team to view",
-				Format:    anyRegex,
-				MultiWord: true,
+		Options: map[string]*cmd.Option{
+			"team": &cmd.Option{
+				Key:      "team",
+				HelpText: "the name of the team to view",
+				Format:   anyRegex,
+				Required: true,
 			},
 		},
 		HandleFunc: ch,
@@ -29,12 +28,12 @@ func NewViewTeamCmd(ch cmd.CommandHandler) *cmd.Command {
 func (b *Bot) viewTeam(c cmd.Context) (string, slack.PostMessageParameters) {
 	params := slack.PostMessageParameters{}
 	team := model.Team{
-		Name: c.Args[0].Value,
+		Name: c.Options["team"].Value,
 	}
 	if err := b.dal.GetTeamByName(&team); err != nil {
 		log.WithError(err).Error("Failed to get team " + team.Name)
 		return "Failed to get team " + team.Name, params
 	}
 	params.Attachments = team.SlackAttachments()
-	return "Team " + c.Args[0].Value, params
+	return "Team " + team.Name, params
 }

--- a/bot/view_user.go
+++ b/bot/view_user.go
@@ -12,13 +12,12 @@ func NewViewUserCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "view-user",
 		HelpText: "View information about a user",
-		Options:  map[string]*cmd.Option{},
-		Args: []cmd.Argument{
-			cmd.Argument{
-				Name:      "username",
-				HelpText:  "the slack handle of the user to view",
-				Format:    anyRegex,
-				MultiWord: false,
+		Options: map[string]*cmd.Option{
+			"user": &cmd.Option{
+				Key:      "user",
+				HelpText: "the slack handle of the user to view",
+				Format:   anyRegex,
+				Required: true,
 			},
 		},
 		HandleFunc: ch,
@@ -28,13 +27,14 @@ func NewViewUserCmd(ch cmd.CommandHandler) *cmd.Command {
 // viewUser displays a user's information.
 func (b *Bot) viewUser(c cmd.Context) (string, slack.PostMessageParameters) {
 	params := slack.PostMessageParameters{}
+	username := c.Options["user"].Value
 	user := model.Member{
-		SlackID: parseMention(c.Args[0].Value),
+		SlackID: parseMention(username),
 	}
 	if err := b.dal.GetMemberBySlackID(&user); err != nil {
-		log.WithError(err).Error("Failed to get member " + c.Args[0].Value)
-		return "Failed to get member " + c.Args[0].Value, params
+		log.WithError(err).Error("Failed to get member " + username)
+		return "Failed to get member " + username, params
 	}
 	params.Attachments = user.SlackAttachments()
-	return c.Args[0].Value + "'s profile", params
+	return username + "'s profile", params
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -15,7 +14,6 @@ type Command struct {
 	Name       string
 	HelpText   string
 	Options    map[string]*Option
-	Args       []Argument
 	HandleFunc CommandHandler
 }
 
@@ -26,16 +24,12 @@ func (c *Command) Execute(ctx Context) (string, slack.PostMessageParameters, err
 	if err := c.parse(ctx.Message.Text); err != nil {
 		return "", slack.PostMessageParameters{}, err
 	}
-	// Copy options and args to context for use by command handler
+	// Copy options to context for use by command handler
 	ctx.Options = map[string]Option{}
 	for key, opt := range c.Options {
 		ctx.Options[key] = *opt
+		// Clear option value now that it's been copied
 		opt.Value = ""
-	}
-	ctx.Args = []Argument{}
-	for _, arg := range c.Args {
-		ctx.Args = append(ctx.Args, arg)
-		arg.Value = ""
 	}
 	// Pass context to command handler
 	res, params := c.HandleFunc(ctx)
@@ -46,29 +40,20 @@ func (c *Command) Execute(ctx Context) (string, slack.PostMessageParameters, err
 func (c *Command) Help() (string, slack.PostMessageParameters) {
 	usage := "Usage: @rocket " + c.Name
 	opts := ""
-	args := ""
 	attachments := []slack.Attachment{}
 	if len(c.Options) > 0 {
 		usage += " OPTIONS"
 		opts = ""
 		for _, o := range c.Options {
-			opts += fmt.Sprintf("--%s\t%s\n", o.Key, o.HelpText)
+			if o.Required {
+				opts += fmt.Sprintf("%s (required): %s\n", o.Key, o.HelpText)
+			} else {
+				opts += fmt.Sprintf("%s: %s\n", o.Key, o.HelpText)
+			}
 		}
 		attachments = append(attachments, slack.Attachment{
 			Title: "Options",
 			Text:  opts,
-			Color: "#e5e7ea",
-		})
-	}
-	if len(c.Args) > 0 {
-		usage += " ARGUMENTS"
-		args = ""
-		for _, a := range c.Args {
-			args += fmt.Sprintf("%s\t%s\n", a.Name, a.HelpText)
-		}
-		attachments = append(attachments, slack.Attachment{
-			Title: "Arguments",
-			Text:  args,
 			Color: "#e5e7ea",
 		})
 	}
@@ -87,42 +72,19 @@ func (c *Command) parse(cmd string) error {
 	} else if tokens[1] != c.Name {
 		return fmt.Errorf("Invalid command \"%s\"", tokens[1])
 	}
-	if len(tokens) == 2 {
-		// No options or args were given
-		if len(c.Args) == 0 {
-			return nil
-		}
-		return fmt.Errorf("Expected %d argument(s), but received 0", len(c.Args))
-	}
-
-	tokens = tokens[2:]
-	argsAndOpts := strings.Join(tokens, " ")
-
-	// Handle options
-	optionsOnly := regexp.MustCompile("--[a-zA-Z0-9-]+=`[^`]+`")
-	opts := optionsOnly.FindAllString(argsAndOpts, -1)
-	if err := c.parseOptions(opts); err != nil {
-		return err
-	}
-
-	// Remove options
-	for _, o := range opts {
-		argsAndOpts = strings.Replace(argsAndOpts, o, "", -1)
-	}
-
-	// Handle arguments
-	args := strings.Fields(argsAndOpts)
-	if err := c.parseArgs(args); err != nil {
-		return err
-	}
-	return nil
+	// Check options and store their values
+	optionsRegex := regexp.MustCompile("[a-zA-Z-]+=`[^`]+`")
+	opts := optionsRegex.FindAllString(strings.Join(tokens[2:], " "), -1)
+	return c.parseOptions(opts)
 }
 
+// parseOptions checks that the value corresponding to each option matches
+// that option's required format, then stores that value. Returns an error
+// if an option is malformatted, or a required option is missing.
+// opts should be a slice of strings of the format "key=value".
 func (c *Command) parseOptions(opts []string) error {
 	for _, token := range opts {
-		token = token[2:]
-
-		// Extract option key and value
+		// Token has format my-key=`my value`. Extract option key and value
 		parts := strings.SplitN(token, "=", 2)
 		key := parts[0][:len(parts[0])]
 		value := strings.TrimRight(strings.TrimLeft(parts[1], "`"), "`")
@@ -144,49 +106,23 @@ func (c *Command) parseOptions(opts []string) error {
 		}
 		option.Value = value
 	}
-	return nil
-}
 
-func (c *Command) parseArgs(args []string) error {
-	argIndex := 0
-	for i, token := range args {
-		if argIndex >= len(c.Args) {
-			return errors.New("Too many arguments")
-		} else if argIndex == len(c.Args)-1 {
-			// This is the last arg
-			if c.Args[argIndex].MultiWord {
-				token = strings.Join(args[i:], " ")
-				// Check that this argument fits it's specified format
-				if err := c.Args[argIndex].validate(token); err != nil {
-					return err
-				}
-				c.Args[argIndex].Value = token
-				return nil
-			}
+	// Check that we aren't missing any required options
+	for _, option := range c.Options {
+		if option.Required && option.Value == "" {
+			return fmt.Errorf("Missing value for required option \"%s\"", option.Key)
 		}
-
-		// Check that this argument fits it's specified format
-		if err := c.Args[argIndex].validate(token); err != nil {
-			return err
-		}
-		c.Args[argIndex].Value = token
-		argIndex++
-	}
-
-	// Check that all args were provided
-	if argIndex != len(c.Args) {
-		return fmt.Errorf("Expected %d argument(s), but received %d",
-			len(c.Args), argIndex)
 	}
 	return nil
 }
 
-// Option represents an optional parameter that can be passed as part of a
+// Option represents a parameter that can be passed as part of a
 // Rocket command
 type Option struct {
 	Key      string
 	HelpText string
 	Format   *regexp.Regexp
+	Required bool
 	Value    string
 }
 
@@ -201,35 +137,11 @@ func (o *Option) validate(value string) error {
 	return nil
 }
 
-// Argument represents a required parameter that Rocket will check as part of a command.
-// Note that MultiWord==true will cause all trailing words to be assigned to
-// this argument. For this reason, there sould always be a maximum of one
-// multi-word argument in a command, and it should always be the last argument.
-type Argument struct {
-	Name      string
-	HelpText  string
-	Format    *regexp.Regexp
-	Value     string
-	MultiWord bool
-}
-
-// validate returns nil if the given value meets the format requirements for
-// this option, returns the validation error otherwise.
-func (a *Argument) validate(value string) error {
-	// Check that the value meets the required format
-	if !a.Format.MatchString(value) {
-		return fmt.Errorf("Invalid format for argument \"%s\". "+
-			"Format must match regular expression %s.", a.Name, a.Format.String())
-	}
-	return nil
-}
-
 // Context stores a Slack message and the user who sent it.
 type Context struct {
 	Message *slack.Msg
 	User    model.Member
 	Options map[string]Option
-	Args    []Argument
 }
 
 // CommandHandler is the interface all handlers of Rocket commands must implement.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -73,7 +73,7 @@ func (c *Command) parse(cmd string) error {
 		return fmt.Errorf("Invalid command \"%s\"", tokens[1])
 	}
 	// Check options and store their values
-	optionsRegex := regexp.MustCompile("[a-zA-Z-]+=`[^`]+`")
+	optionsRegex := regexp.MustCompile("[a-zA-Z-]+={[^}]+}")
 	opts := optionsRegex.FindAllString(strings.Join(tokens[2:], " "), -1)
 	return c.parseOptions(opts)
 }
@@ -84,10 +84,10 @@ func (c *Command) parse(cmd string) error {
 // opts should be a slice of strings of the format "key=value".
 func (c *Command) parseOptions(opts []string) error {
 	for _, token := range opts {
-		// Token has format my-key=`my value`. Extract option key and value
+		// Token has format my-key={my value}. Extract option key and value
 		parts := strings.SplitN(token, "=", 2)
 		key := parts[0][:len(parts[0])]
-		value := strings.TrimRight(strings.TrimLeft(parts[1], "`"), "`")
+		value := strings.TrimRight(strings.TrimLeft(parts[1], "{"), "}")
 
 		// Check that it is a valid option
 		option := c.Options[key]

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -50,7 +50,7 @@ func testHandler(context Context) (string, slack.PostMessageParameters) {
 }
 
 func TestCommand(t *testing.T) {
-	ctx := getTestContext("@rocket test required=`gre at` optional=`awes =ome`")
+	ctx := getTestContext("@rocket test required={gre at} optional={awes =ome}")
 	ch := func(c Context) (string, slack.PostMessageParameters) {
 		ctx = c
 		return "", slack.PostMessageParameters{}
@@ -63,7 +63,7 @@ func TestCommand(t *testing.T) {
 }
 
 func TestInvalidCommand(t *testing.T) {
-	ctx := getTestContext("@rocket ayyy required=`gre at`")
+	ctx := getTestContext("@rocket ayyy required={gre at}")
 	cmd := getTestCommand(testHandler)
 	_, _, err := cmd.Execute(ctx)
 	assert.NotNil(t, err)
@@ -71,7 +71,7 @@ func TestInvalidCommand(t *testing.T) {
 }
 
 func TestCommandMissingRequiredOption(t *testing.T) {
-	ctx := getTestContext("@rocket test optional=`noooo`")
+	ctx := getTestContext("@rocket test optional={noooo}")
 	cmd := getTestCommand(testHandler)
 	_, _, err := cmd.Execute(ctx)
 	assert.NotNil(t, err)
@@ -79,7 +79,7 @@ func TestCommandMissingRequiredOption(t *testing.T) {
 }
 
 func TestCommandDuplicateOption(t *testing.T) {
-	ctx := getTestContext("@rocket test required=`ayy` required=`letsgo`")
+	ctx := getTestContext("@rocket test required={ayy} required={letsgo}")
 	cmd := getTestCommand(testHandler)
 	_, _, err := cmd.Execute(ctx)
 	assert.NotNil(t, err)
@@ -87,7 +87,7 @@ func TestCommandDuplicateOption(t *testing.T) {
 }
 
 func TestCommandUnrecognizedOption(t *testing.T) {
-	ctx := getTestContext("@rocket test plx=`plox`")
+	ctx := getTestContext("@rocket test plx={plox}")
 	cmd := getTestCommand(testHandler)
 	_, _, err := cmd.Execute(ctx)
 	assert.NotNil(t, err)
@@ -95,7 +95,7 @@ func TestCommandUnrecognizedOption(t *testing.T) {
 }
 
 func TestCommandInvalidOptFormat(t *testing.T) {
-	ctx := getTestContext("@rocket test required=`test`")
+	ctx := getTestContext("@rocket test required={test}")
 	cmd := getTestCommand(testHandler)
 	cmd.Options["required"].Format, _ = regexp.Compile("^[0-9]")
 	_, _, err := cmd.Execute(ctx)

--- a/model/team.go
+++ b/model/team.go
@@ -13,6 +13,7 @@ type Team struct {
 
 	Name         string    `json:"name"`
 	GithubTeamID int       `sql:",pk" json:"-" pg:"github_team_id"`
+	Platform     string    `json:"platform"`
 	CreatedAt    time.Time `json:"-"`
 
 	Members []*Member `sql:"-" json:"members" pg:",many2many:team_members,joinFK:Member"`
@@ -33,6 +34,10 @@ func (t *Team) SlackAttachments() []slack.Attachment {
 	attachments := []slack.Attachment{
 		slack.Attachment{
 			Text:  "Name: " + t.Name,
+			Color: "good",
+		},
+		slack.Attachment{
+			Text:  "Platform: " + t.Platform,
 			Color: "good",
 		},
 		slack.Attachment{

--- a/schema/migrations/5_add_team_platform.sql
+++ b/schema/migrations/5_add_team_platform.sql
@@ -1,0 +1,2 @@
+ALTER TABLE teams
+ADD COLUMN platform TEXT;

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -16,6 +16,7 @@ DROP TABLE IF EXISTS teams;
 CREATE TABLE teams (
     name TEXT UNIQUE,
     github_team_id INTEGER PRIMARY KEY,
+    platform TEXT,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (now() at time zone 'utc')
 );
 


### PR DESCRIPTION
* Update command framework. Now you pass options to commands like this:

```
@rocket set name={Bruno}
```

 There is no longer any notion of an "argument" for a command. Everything is an option. I did this because it's much easier to just treat all "arguments" as key-value pairs. It also allows us to work around the issue of only being able to support at most one multi-word argument in a command. Because all values for options are enclosed in `{}` you can put whitespace in your value without the framework interpreting it as multiple arguments. Required options will be enforced by the framework, so they are essentially arguments. I switched from using backticks to enclose the value assigned to some option to using `{}` because Slack won't do @mentions properly if you enclose them in backticks.

* Update commands to use command framework updates.
* Update `team` to have a `platform` field indicating what type of team it is. This will be useful to people visiting the website as many of our team names don't really hint at the platform they're developing on.