### PR TITLE
Recover from WebSocket failures with backoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ rocket
 .env
 **/debug.test
 pgdata
+.app.env
+.db.env

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -2,7 +2,6 @@ package bot
 
 import (
 	"strings"
-	"time"
 
 	"github.com/nlopes/slack"
 	log "github.com/sirupsen/logrus"
@@ -79,7 +78,7 @@ func New(cfg *config.Config, dal *data.DAL, gh *github.API, log *log.Entry) *Bot
 // Start causes an already initialized bot instance to begin listening for
 // and responding to commands sent on its Slack channel.
 func (b *Bot) Start() {
-	go b.manageConnection()
+	go b.rtm.ManageConnection()
 
 	for evt := range b.rtm.IncomingEvents {
 		switch evt.Data.(type) {
@@ -91,33 +90,6 @@ func (b *Bot) Start() {
 			b.handleUserChange(evt.Data.(*slack.TeamJoinEvent).User)
 		case *slack.UserChangeEvent:
 			b.handleUserChange(evt.Data.(*slack.UserChangeEvent).User)
-		}
-	}
-}
-
-// Manages a Slack WebSocket connection and re-establishes the connection
-// when errors occur.
-func (b *Bot) manageConnection() {
-	consecutiveRetries := 0
-	for {
-		start := time.Now()
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					b.log.Info("Recovered from panic in manageConnection")
-				}
-			}()
-			b.rtm.ManageConnection()
-		}()
-		if consecutiveRetries >= 2 {
-			panic("Failed to maintain WebSocket connection after 3 attempts")
-		} else if time.Since(start) < time.Second*3 {
-			// The connection is failing quite quickly. Let's back off.
-			consecutiveRetries++
-			time.Sleep(time.Duration(10*consecutiveRetries) * time.Second)
-		} else {
-			// The connection failed but only after a while
-			consecutiveRetries = 0
 		}
 	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c28e4307cd1fbc0f19108c7696706b0148d0d012a8cc8400d4b0ac4597194098
-updated: 2018-03-27T23:34:41.484046-07:00
+hash: a8d46952c05f56caefe13aeda3d2ecd60ea1f7d8acd359008883e75c839826ea
+updated: 2018-04-15T10:04:53.506844-07:00
 imports:
 - name: github.com/go-pg/pg
   version: 81c90201251e3435753431f688d6be110a0806ca
@@ -30,7 +30,7 @@ imports:
 - name: github.com/jinzhu/inflection
   version: 04140366298a54a039076d798123ffa108fff46c
 - name: github.com/nlopes/slack
-  version: 8ab4d0b364ef1e9af5d102531da20d5ec902b6c4
+  version: 3472fa2dd0347a0d966feaf49d3e197d50e9576e
 - name: github.com/sirupsen/logrus
   version: 90150a8ed11b6ce285e77e8af2b0109559ce4777
 - name: golang.org/x/crypto

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/ubclaunchpad/rocket
 import:
 - package: github.com/nlopes/slack
-  version: ^0.1.0
+  version: 3472fa2dd0347a0d966feaf49d3e197d50e9576e
 - package: github.com/go-pg/pg
   version: 6.4.0
 - package: github.com/sirupsen/logrus


### PR DESCRIPTION
Fixes #60 

I've just updated our Slack dependency, so hopefully that fixes the issue. It seems they've improved their error handling in reading from the WebSocket. If the same error crops up again I'll have to resort to some form of the `recover` solution I has before.