### PR TITLE
Add edit-team command, update team commands

### DIFF
--- a/core/add_team.go
+++ b/core/add_team.go
@@ -27,6 +27,12 @@ func NewAddTeamCmd(ch cmd.CommandHandler) *cmd.Command {
 				Format:   cmd.AnyRegex,
 				Required: true,
 			},
+			"github": &cmd.Option{
+				Key:      "github",
+				HelpText: "the name of the team to create on GitHub",
+				Format:   cmd.NameRegex,
+				Required: false,
+			},
 		},
 		HandleFunc: ch,
 	}
@@ -42,8 +48,12 @@ func (core *CorePlugin) addTeam(c cmd.Context) (string, slack.PostMessageParamet
 
 	teamName := c.Options["name"].Value
 	platform := c.Options["platform"].Value
-	// teamName = "Great Team", ghTeamName = "great-team"
+
+	// Set custom GitHub team name if applicable
 	ghTeamName := strings.ToLower(strings.Replace(teamName, " ", "-", -1))
+	if c.Options["github"].Value != "" {
+		ghTeamName = c.Options["github"].Value
+	}
 
 	// Create the team on GitHub
 	ghTeam, err := core.Bot.GitHub.CreateTeam(ghTeamName)

--- a/core/core.go
+++ b/core/core.go
@@ -34,6 +34,7 @@ func (cp *CorePlugin) Commands() []*cmd.Command {
 		NewViewTeamCmd(cp.viewTeam),
 		NewAddUserCmd(cp.addUser),
 		NewAddTeamCmd(cp.addTeam),
+		NewEditTeamCmd(cp.editTeam),
 		NewAddAdminCmd(cp.addAdmin),
 		NewRemoveAdminCmd(cp.removeAdmin),
 		NewRemoveUserCmd(cp.removeUser),

--- a/core/edit_team.go
+++ b/core/edit_team.go
@@ -1,0 +1,68 @@
+package core
+
+import (
+	"github.com/nlopes/slack"
+	log "github.com/sirupsen/logrus"
+	"github.com/ubclaunchpad/rocket/cmd"
+	"github.com/ubclaunchpad/rocket/model"
+)
+
+// NewEditTeamCmd returns an add team command that creates a new Launch Pad team
+func NewEditTeamCmd(ch cmd.CommandHandler) *cmd.Command {
+	return &cmd.Command{
+		Name:     "edit-team",
+		HelpText: "Update an existing Launch Pad team",
+		Options: map[string]*cmd.Option{
+			"team": &cmd.Option{
+				Key:      "team",
+				HelpText: "the name of the existing team",
+				Format:   cmd.AnyRegex,
+				Required: true,
+			},
+			"name": &cmd.Option{
+				Key:      "name",
+				HelpText: "the new name of the team",
+				Format:   cmd.AnyRegex,
+				Required: false,
+			},
+			"platform": &cmd.Option{
+				Key:      "platform",
+				HelpText: "the new platform the team develops on (i.e iOS, Android etc)",
+				Format:   cmd.AnyRegex,
+				Required: false,
+			},
+		},
+		HandleFunc: ch,
+	}
+}
+
+// editTeam edits an existing Launch Pad team.
+func (core *CorePlugin) editTeam(c cmd.Context) (string, slack.PostMessageParameters) {
+	noParams := slack.PostMessageParameters{}
+	if !c.User.IsAdmin {
+		return "You must be an admin to use this command", noParams
+	}
+
+	currentName := c.Options["team"].Value
+	currentTeam := &model.Team{
+		Name: currentName,
+	}
+	newTeam := &model.Team{
+		Name:     c.Options["name"].Value,
+		Platform: c.Options["platform"].Value,
+	}
+
+	// Try get existing team from DB
+	if err := core.Bot.DAL.GetTeamByName(currentTeam); err != nil {
+		core.Bot.Log.WithError(err).Errorf("failed to update team %s", currentName)
+		return "Failed to update team " + currentName, noParams
+	}
+
+	// Finally, update team in DB
+	if err := core.Bot.DAL.UpdateTeam(currentTeam, newTeam); err != nil {
+		log.WithError(err).Errorf("failed to update team %s", currentName)
+		return "Failed to update team " + currentName, noParams
+	}
+
+	return "`" + currentName + "` has been updated :tada:", noParams
+}

--- a/data/team.go
+++ b/data/team.go
@@ -42,6 +42,21 @@ func (dal *DAL) CreateTeam(team *model.Team) error {
 	return err
 }
 
+func (dal *DAL) UpdateTeam(currentTeam, newTeam *model.Team) error {
+	// Only update values if they were set
+	if newTeam.Name != "" {
+		currentTeam.Name = newTeam.Name
+	}
+	if newTeam.Platform != "" {
+		currentTeam.Platform = newTeam.Platform
+	}
+	_, err := dal.db.Model(currentTeam).
+		Update(
+			"name", currentTeam.Name,
+			"platform", currentTeam.Platform)
+	return err
+}
+
 func (dal *DAL) DeleteTeamByName(team *model.Team) error {
 	_, err := dal.db.Model(team).
 		Where("name = ?name").

--- a/github/github.go
+++ b/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/ubclaunchpad/rocket/config"
@@ -81,6 +82,19 @@ func (api *API) CreateTeam(name string) (*gh.Team, error) {
 	}
 	t, _, err := api.Organizations.CreateTeam(context.Background(), "ubclaunchpad", team)
 	return t, err
+}
+
+func (api *API) GetTeam(id int) (*gh.Team, error) {
+	teams, _, err := api.Organizations.ListTeams(context.Background(), "ubclaunchpad", nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, team := range teams {
+		if *team.ID == id {
+			return team, nil
+		}
+	}
+	return nil, fmt.Errorf("GitHub team with ID %d not found", id)
 }
 
 func (api *API) RemoveTeam(id int) error {

--- a/model/team.go
+++ b/model/team.go
@@ -13,7 +13,7 @@ type Team struct {
 
 	Name         string    `json:"name"`
 	GithubTeamID int       `sql:",pk" json:"-" pg:"github_team_id"`
-	Platform     string    `json:"platform"`
+	Platform     string    `json:"platform" pg:"platform"`
 	CreatedAt    time.Time `json:"-"`
 
 	Members []*Member `sql:"-" json:"members" pg:",many2many:team_members,joinFK:Member"`


### PR DESCRIPTION
## Changes

Once this is merged we should be able to do the following

* Specify custom GitHub team names when creating new teams
* View GitHub team names when viewing a team
* Edit the name and platform of an existing team

## Testing

You can try this you in Slack right now. I've already deployed it as a test and it seems to be working alright.