### PR TITLE
Move is_tech_lead to team_members and misc improvements

### DIFF
--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,5 +1,9 @@
 # Use Postgres as base image
 FROM postgres
 
-# Copy the SQL script for initializing the DB to the Postgres container
-ADD ./schema/tables.sql /tables.sql
+# Copy the SQL scripts for initializing the DB to the Postgres container
+ADD schema /etc/rocket
+
+# Add the schema to Postgres' initdb.d so the DB is set up automatically when
+# the container starts
+ADD schema/tables.sql /docker-entrypoint-initdb.d/init.sql

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,28 @@
+MIGRATION ?= tables
+
 all: deps
 
+# Install rocket as an executable
 rocket:
 	go install
 
+# Install dependencies
 .PHONY: deps
 deps:
 	dep ensure
 
+# Clean up unwanted files
 .PHONY: clean
 clean:
 	rm -f rocket
 	docker-compose -f docker-compose.test.yml down
 
+# Run all unit tests and report coverage
 .PHONY: test
 test:
 	go test ./... -short -cover
 
+# Run all integration tests and report coverage
 .PHONY: test-integration
 test-integration: mock-db
 	go test ./... -cover
@@ -26,10 +33,27 @@ test-integration: mock-db
 mock-db:
 	docker-compose -f docker-compose.test.yml up -d
 
+# Start the Rocket and Postgres containers
 .PHONY: docker
 docker:
 	docker-compose up -d
 
+# Build and start the Rocket container
 .PHONY: build
 build:
 	docker-compose up -d --build rocket
+
+# Run a migration specified by MIGRATION
+# e.g: $ make migration MIGRATION=6_add_is_tech_lead
+.PHONY: migrate
+migrate:
+	@docker-compose exec postgres bash -c \
+		"psql -U \$$POSTGRES_USER -d \$$POSTGRES_DB -f /etc/rocket/migrations/${MIGRATION}.sql"
+
+# Dump Rocket's DB to a file called rocket_dump.sql in the CWD
+.PHONY: dump
+dump:
+	@docker-compose exec postgres bash -c \
+		"pg_dump -f /tmp/rocket_dump.sql -U \$$POSTGRES_USER -d \$$POSTGRES_DB"
+	@docker cp rocket_postgres_1:/tmp/rocket_dump.sql rocket_dump.sql
+	@echo Created dump file "$(shell pwd)/rocket_dump.sql"

--- a/README.md
+++ b/README.md
@@ -148,4 +148,10 @@ Note that all the data stored in the DB is mounted into the Postgres container f
 
 #### Migrations
 
-If you're updating the DB schema because you want to store a new resource or update an existing one: you'll need to create a migration script under [schema/migrations](schema/migrations) and run it against the DB the same way you would run `schema.sql`. Don't forget to update `schema.sql` to include any changes you apply in your migrations.
+If you're updating the DB schema because you want to store a new resource or update an existing one you'll need to create a migration script under [schema/migrations](schema/migrations) and run it against the DB:
+
+```bash
+make migrate MIGRATION=7_move_is_tech_lead_to_team_members
+```
+
+Don't forget to update `tables.sql` to include any changes you apply in your migrations.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -61,7 +61,7 @@ func (c *Command) Help() (string, slack.PostMessageParameters) {
 			if o.Required {
 				opts += fmt.Sprintf("`%s` (required): %s\n", o.Key, o.HelpText)
 			} else {
-				opts += fmt.Sprintf("%s: %s\n", o.Key, o.HelpText)
+				opts += fmt.Sprintf("`%s`: %s\n", o.Key, o.HelpText)
 			}
 		}
 		attachments = append(attachments, slack.Attachment{

--- a/data/member.go
+++ b/data/member.go
@@ -1,6 +1,10 @@
 package data
 
-import "github.com/ubclaunchpad/rocket/model"
+import (
+	"fmt"
+
+	"github.com/ubclaunchpad/rocket/model"
+)
 
 // GetMemberBySlackID populates the given member with information from the DB
 // or returns an error.
@@ -14,14 +18,6 @@ func (dal *DAL) GetMemberBySlackID(member *model.Member) error {
 // the DB or returns an error.
 func (dal *DAL) GetMembers(members *model.Members) error {
 	return dal.db.Model(members).
-		Order("name ASC").
-		Select()
-}
-
-// GetTechLeads populates given members with all current tech leads
-func (dal *DAL) GetTechLeads(members *model.Members) error {
-	return dal.db.Model(members).
-		Where("is_tech_lead = 't'").
 		Order("name ASC").
 		Select()
 }
@@ -84,98 +80,103 @@ func (dal *DAL) DeleteMember(member *model.Member) error {
 // SetMemberName updates the name of the given member in the DB or returns
 // an error.
 func (dal *DAL) SetMemberName(member *model.Member) error {
-	_, err := dal.db.Model(member).
+	res, err := dal.db.Model(member).
 		WherePK().
 		Set("name = ?name").
 		Update()
-
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("No such member %s", member.SlackID)
+	}
 	return err
 }
 
 // SetMemberEmail updates the name of the given member in the DB or returns
 // an error.
 func (dal *DAL) SetMemberEmail(member *model.Member) error {
-	_, err := dal.db.Model(member).
+	res, err := dal.db.Model(member).
 		WherePK().
 		Set("email = ?email").
 		Update()
-
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("No such member %s", member.SlackID)
+	}
 	return err
 }
 
 // SetMemberGitHubUsername updates the GitHub username of the given member in
 // the DB or returns an error.
 func (dal *DAL) SetMemberGitHubUsername(member *model.Member) error {
-	_, err := dal.db.Model(member).
+	res, err := dal.db.Model(member).
 		WherePK().
 		Set("github_username = ?github_username").
 		Update()
-
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("No such member %s", member.SlackID)
+	}
 	return err
 }
 
 // SetMemberMajor updates the major of the given member in the DB or returns
 // an error.
 func (dal *DAL) SetMemberMajor(member *model.Member) error {
-	_, err := dal.db.Model(member).
+	res, err := dal.db.Model(member).
 		WherePK().
 		Set("program = ?program").
 		Update()
-
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("No such member %s", member.SlackID)
+	}
 	return err
 }
 
 // SetMemberPosition updates the position of the given member in the DB or returns
 // an error.
 func (dal *DAL) SetMemberPosition(member *model.Member) error {
-	_, err := dal.db.Model(member).
+	res, err := dal.db.Model(member).
 		WherePK().
 		Set("position = ?position").
 		Update()
-
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("No such member %s", member.SlackID)
+	}
 	return err
 }
 
 // SetMemberBiography updates the bio of the given member in the DB or returns
 // an error.
 func (dal *DAL) SetMemberBiography(member *model.Member) error {
-	_, err := dal.db.Model(member).
+	res, err := dal.db.Model(member).
 		WherePK().
 		Set("biography = ?biography").
 		Update()
-
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("No such member %s", member.SlackID)
+	}
 	return err
 }
 
 // SetMemberImageURL updates the image URL of the given member in the DB or returns
 // an error.
 func (dal *DAL) SetMemberImageURL(member *model.Member) error {
-	_, err := dal.db.Model(member).
+	res, err := dal.db.Model(member).
 		WherePK().
 		Set("image_url = ?image_url").
 		Update()
-
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("No such member %s", member.SlackID)
+	}
 	return err
 }
 
 // SetMemberIsAdmin updates whether the given member is an admin in the DB
 // or returns an error.
 func (dal *DAL) SetMemberIsAdmin(member *model.Member) error {
-	_, err := dal.db.Model(member).
+	res, err := dal.db.Model(member).
 		WherePK().
 		Set("is_admin = ?is_admin").
 		Update()
-
-	return err
-}
-
-// SetMemberIsTechLead updates whether the given member is a tech lead in
-// the DB or returns an error.
-func (dal *DAL) SetMemberIsTechLead(member *model.Member) error {
-	_, err := dal.db.Model(member).
-		WherePK().
-		Set("is_tech_lead = ?is_tech_lead").
-		Update()
-
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("No such member %s", member.SlackID)
+	}
 	return err
 }

--- a/data/team_member.go
+++ b/data/team_member.go
@@ -1,8 +1,12 @@
 package data
 
-import "github.com/ubclaunchpad/rocket/model"
+import (
+	"fmt"
 
-// CreateTeamMember inserts a team member into the database
+	"github.com/ubclaunchpad/rocket/model"
+)
+
+// CreateTeamMember inserts a team member into the database or returns an error.
 func (dal *DAL) CreateTeamMember(member *model.TeamMember) error {
 	_, err := dal.db.Model(member).
 		OnConflict("DO NOTHING").
@@ -10,7 +14,58 @@ func (dal *DAL) CreateTeamMember(member *model.TeamMember) error {
 	return err
 }
 
-// DeleteTeamMember removes team member from database
+// GetTeamMember gets a team member by GithubUserId and MemberSlackID or returns
+// an error.
+func (dal *DAL) GetTeamMember(teamMember *model.TeamMember) error {
+	return dal.db.Model(teamMember).
+		Where("team_github_team_id = ?team_github_team_id").
+		Where("member_slack_id = ?member_slack_id").
+		Select()
+}
+
+// SetIsTechLead sets is_tech_lead to the value on the given team member or
+// returns an error if there is no such team member.
+func (dal *DAL) SetIsTechLead(teamMember *model.TeamMember) error {
+	res, err := dal.db.Model(teamMember).
+		Where("team_github_team_id = ?team_github_team_id AND " +
+			"member_slack_id = ?member_slack_id").
+		Set("is_tech_lead = ?is_tech_lead").
+		Update()
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("No such team member member_slack_id=%s "+
+			"team_github_team_id=%d",
+			teamMember.MemberSlackID, teamMember.GithubTeamID)
+	}
+	return err
+}
+
+// GetTechLeads returns a list of all members who are tech leads, or returns
+// an error.
+func (dal *DAL) GetTechLeads() (*model.Members, error) {
+	members := &model.Members{}
+	err := dal.db.Model(members).
+		Where("slack_id in (SELECT member_slack_id FROM team_members " +
+			"WHERE is_tech_lead = true)").
+		Order("name ASC").
+		Select()
+	return members, err
+}
+
+// GetTechLeadsByTeam returns a list of all members who are tech leads of the
+// given team, or an error.
+func (dal *DAL) GetTechLeadsByTeam(team *model.Team) (*model.Members, error) {
+	members := &model.Members{}
+	err := dal.db.Model(members).
+		Where("slack_id in (SELECT member_slack_id FROM team_members "+
+			"WHERE is_tech_lead = true and team_github_team_id = ?)",
+			team.GithubTeamID).
+		Order("name ASC").
+		Select()
+	return members, err
+}
+
+// DeleteTeamMember removes the given team member from database or
+// returns an error.
 func (dal *DAL) DeleteTeamMember(member *model.TeamMember) error {
 	_, err := dal.db.Model(member).
 		Where("team_github_team_id = ?team_github_team_id").

--- a/model/member.go
+++ b/model/member.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/nlopes/slack"
@@ -19,7 +20,6 @@ type Member struct {
 	Position       string    `json:"position"`
 	Biography      string    `json:"biography"`
 	ImageURL       string    `json:"imageUrl"`
-	IsTechLead     bool      `json:"isTechLead"`
 	IsAdmin        bool      `json:"-"`
 	CreatedAt      time.Time `json:"-"`
 }
@@ -42,6 +42,10 @@ func (m *Member) SlackAttachments() []slack.Attachment {
 			Color: "good",
 		},
 		slack.Attachment{
+			Text:  fmt.Sprintf("Admin: %t", m.IsAdmin),
+			Color: "good",
+		},
+		slack.Attachment{
 			Text:  "Position: " + m.Position,
 			Color: "good",
 		},
@@ -57,19 +61,6 @@ func (m *Member) SlackAttachments() []slack.Attachment {
 			Text:  "Biography: " + m.Biography,
 			Color: "good",
 		},
-	}
-
-	for _, attachment := range attachments {
-		if len(attachment.Text) == 0 {
-			attachment.Color = "danger"
-		}
-	}
-
-	if m.IsTechLead {
-		attachments = append(attachments, slack.Attachment{
-			Text:  "Tech Lead",
-			Color: "good",
-		})
 	}
 
 	return attachments

--- a/model/team.go
+++ b/model/team.go
@@ -25,15 +25,14 @@ type Teams []*Team
 // SlackAttachments creates and returns a set of Slack attachments (strictly
 // for use in messages sent to Slack clients) that describe the team's name
 // and list of members.
-func (t *Team) SlackAttachments() []slack.Attachment {
+func (t *Team) SlackAttachments(techLeads Members) []slack.Attachment {
 	members := []string{}
 	leads := []string{}
 	for _, member := range t.Members {
-		if !member.IsTechLead {
-			members = append(members, member.Name)
-		} else {
-			leads = append(leads, member.Name)
-		}
+		members = append(members, member.Name)
+	}
+	for _, lead := range techLeads {
+		leads = append(leads, lead.Name)
 	}
 	membersString := strings.Join(members, ", ")
 	leadsString := strings.Join(leads, ", ")

--- a/model/team_member.go
+++ b/model/team_member.go
@@ -3,8 +3,9 @@ package model
 // TeamMember represents the concrete relationship between teams and members
 // in the database.
 type TeamMember struct {
-	GithubTeamID  int    `sql:"team_github_team_id,pk"`
-	MemberSlackID string `sql:",pk"`
+	GithubTeamID  int    `sql:"team_github_team_id,pk" json:"-"`
+	MemberSlackID string `sql:",pk" json:"-"`
+	IsTechLead    bool   `json:"isTechLead"`
 
 	Team   *Team   `sql:"-"`
 	Member *Member `sql:"-"`

--- a/plugins/core/add_team.go
+++ b/plugins/core/add_team.go
@@ -13,7 +13,7 @@ import (
 func NewAddTeamCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "add-team",
-		HelpText: "Create a new Launch Pad team (admins and tech leads only)",
+		HelpText: "Create a new Launch Pad team (admins only)",
 		Options: map[string]*cmd.Option{
 			"name": &cmd.Option{
 				Key:      "name",
@@ -42,8 +42,8 @@ func NewAddTeamCmd(ch cmd.CommandHandler) *cmd.Command {
 func (core *Plugin) addTeam(c cmd.Context) (string, slack.PostMessageParameters) {
 	noParams := slack.PostMessageParameters{}
 
-	if !c.User.IsAdmin && !c.User.IsTechLead {
-		return "You must be an admin or tech lead to use this command", noParams
+	if !c.User.IsAdmin {
+		return "You must be an admin to use this command", noParams
 	}
 
 	teamName := c.Options["name"].Value

--- a/plugins/core/add_user.go
+++ b/plugins/core/add_user.go
@@ -13,7 +13,7 @@ import (
 func NewAddUserCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "add-user",
-		HelpText: "Add a user to a team (admins and tech leads only)",
+		HelpText: "Add a user to a team (admins only)",
 		Options: map[string]*cmd.Option{
 			"user": &cmd.Option{
 				Key:      "user",
@@ -38,8 +38,8 @@ func (core *Plugin) addUser(c cmd.Context) (string, slack.PostMessageParameters)
 	username := c.Options["user"].Value
 	teamName := c.Options["team"].Value
 
-	if !c.User.IsAdmin && !c.User.IsTechLead {
-		return "You must be an admin or tech lead to use this command", noParams
+	if !c.User.IsAdmin {
+		return "You must be an admin to use this command", noParams
 	}
 
 	team := model.Team{

--- a/plugins/core/admins.go
+++ b/plugins/core/admins.go
@@ -25,9 +25,12 @@ func (core *Plugin) listAdmins(c cmd.Context) (string, slack.PostMessageParamete
 		log.WithError(err).Error("failed to get admins")
 		return "Failed to get admins", noParams
 	}
-	names := ""
+	msg := ""
 	for _, member := range members {
-		names += member.Name + "\n"
+		msg += member.Name + "\n"
 	}
-	return names, noParams
+	if len(msg) == 0 {
+		msg = "There are currently no admins :feelsbadman:"
+	}
+	return msg, noParams
 }

--- a/plugins/core/edit_team.go
+++ b/plugins/core/edit_team.go
@@ -11,7 +11,7 @@ import (
 func NewEditTeamCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "edit-team",
-		HelpText: "Update an existing Launch Pad team (admins and tech leads only)",
+		HelpText: "Update an existing Launch Pad team (admins only)",
 		Options: map[string]*cmd.Option{
 			"team": &cmd.Option{
 				Key:      "team",
@@ -39,8 +39,8 @@ func NewEditTeamCmd(ch cmd.CommandHandler) *cmd.Command {
 // editTeam edits an existing Launch Pad team.
 func (core *Plugin) editTeam(c cmd.Context) (string, slack.PostMessageParameters) {
 	noParams := slack.PostMessageParameters{}
-	if !c.User.IsAdmin && !c.User.IsTechLead {
-		return "You must be an admin or tech lead to use this command", noParams
+	if !c.User.IsAdmin {
+		return "You must be an admin to use this command", noParams
 	}
 
 	currentName := c.Options["team"].Value

--- a/plugins/core/help.go
+++ b/plugins/core/help.go
@@ -54,7 +54,7 @@ func (core *Plugin) help(c cmd.Context) (string, slack.PostMessageParameters) {
 			}
 			cmds += fmt.Sprintf("%s%s %s\n", cmd.Name, dividerSpace, cmd.HelpText)
 		}
-		cmds += "\n```"
+		cmds += "```"
 		commands := slack.Attachment{
 			Title: "Commands",
 			Text:  cmds,

--- a/plugins/core/techleads.go
+++ b/plugins/core/techleads.go
@@ -4,7 +4,6 @@ import (
 	"github.com/nlopes/slack"
 	log "github.com/sirupsen/logrus"
 	"github.com/ubclaunchpad/rocket/cmd"
-	"github.com/ubclaunchpad/rocket/model"
 )
 
 // NewTechLeadsCmd returns a teams command that displays a list of Launch Pad teams
@@ -17,17 +16,20 @@ func NewTechLeadsCmd(ch cmd.CommandHandler) *cmd.Command {
 	}
 }
 
-// listAdmins displays Launch Pad admins
+// listTechLeads displays Launch Pad tech leads
 func (core *Plugin) listTechLeads(c cmd.Context) (string, slack.PostMessageParameters) {
 	noParams := slack.PostMessageParameters{}
-	members := model.Members{}
-	if err := core.Bot.DAL.GetTechLeads(&members); err != nil {
+	members, err := core.Bot.DAL.GetTechLeads()
+	if err != nil {
 		log.WithError(err).Error("failed to get tech leads")
 		return "Failed to get tech leads", noParams
 	}
-	names := ""
-	for _, member := range members {
-		names += member.Name + "\n"
+	msg := ""
+	for _, member := range *members {
+		msg += member.Name + "\n"
 	}
-	return names, noParams
+	if len(msg) == 0 {
+		msg = "There are currently no tech leads :feelsbadman:"
+	}
+	return msg, noParams
 }

--- a/plugins/core/toggle_admin.go
+++ b/plugins/core/toggle_admin.go
@@ -37,18 +37,18 @@ func (core *Plugin) toggleAdmin(c cmd.Context) (string, slack.PostMessageParamet
 	member := &model.Member{SlackID: cmd.ParseMention(username)}
 	err := core.Bot.DAL.GetMemberBySlackID(member)
 	if err != nil {
-		log.WithError(err).Error("Failed to get %s", username)
+		log.WithError(err).Errorf("Failed to get %s", username)
 		return "Failed to find user", noParams
 	}
 
 	// Update member admin status
 	member.IsAdmin = !member.IsAdmin
 	if err := core.Bot.DAL.SetMemberIsAdmin(member); err != nil {
-		log.WithError(err).Error("Failed to update %s's admin status", username)
+		log.WithError(err).Errorf("Failed to update %s's admin status", username)
 		return "Failed to update admin status", noParams
 	}
 	return fmt.Sprintf(
-		"Set %s's admin status has been set to %t :tada:",
+		"%s's admin status has been set to %t :tada:",
 		cmd.ToMention(member.SlackID), member.IsAdmin,
 	), noParams
 }

--- a/plugins/core/toggle_techlead.go
+++ b/plugins/core/toggle_techlead.go
@@ -9,16 +9,24 @@ import (
 	"github.com/ubclaunchpad/rocket/model"
 )
 
-// NewToggleTechLeadCmd returns an add tech lead command that toggles an existing
-// user's tech lead status (this action can only be performed by admins)
+// NewToggleTechLeadCmd returns a toggle tech lead command that makes an
+// existing user the teach lead of a given team if they are not already
+// a tech lead of that team, otherwise it removes them from the tech leads role
+// on that team.
 func NewToggleTechLeadCmd(ch cmd.CommandHandler) *cmd.Command {
 	return &cmd.Command{
 		Name:     "toggle-tech-lead",
-		HelpText: "Toggle an existing user's tech lead status (admins only)",
+		HelpText: "Make an existing user a tech lead of an existing team (admins only)",
 		Options: map[string]*cmd.Option{
 			"user": &cmd.Option{
 				Key:      "user",
 				HelpText: "the Slack handle of the user to update",
+				Format:   cmd.AnyRegex,
+				Required: true,
+			},
+			"team": &cmd.Option{
+				Key:      "team",
+				HelpText: "the name of the team on which to set the new tech lead",
 				Format:   cmd.AnyRegex,
 				Required: true,
 			},
@@ -27,28 +35,63 @@ func NewToggleTechLeadCmd(ch cmd.CommandHandler) *cmd.Command {
 	}
 }
 
-// toggleTechLead toggles an existing user's tech lead status
+// toggleTechLead makes an existing user the teach lead of a given team if they
+// are not already a tech lead of that team, otherwise it removes them from
+// the tech leads role on that team.
 func (core *Plugin) toggleTechLead(c cmd.Context) (string, slack.PostMessageParameters) {
 	noParams := slack.PostMessageParameters{}
 	if !c.User.IsAdmin {
 		return "You must be an admin to use this command", noParams
 	}
+
+	// Fetch the member
 	username := c.Options["user"].Value
 	member := &model.Member{SlackID: cmd.ParseMention(username)}
-	err := core.Bot.DAL.GetMemberBySlackID(member)
-	if err != nil {
-		log.WithError(err).Error("Failed to get %s", username)
+	if err := core.Bot.DAL.GetMemberBySlackID(member); err != nil {
+		log.WithError(err).Errorf("Failed to get %s", username)
 		return "Failed to find user", noParams
 	}
 
+	// Fetch team
+	teamName := c.Options["team"].Value
+	team := &model.Team{Name: teamName}
+	if err := core.Bot.DAL.GetTeamByName(team); err != nil {
+		log.WithError(err).Errorf("Failed to get %s", teamName)
+		return "Failed to find team", noParams
+	}
+
+	userMention := cmd.ToMention(member.SlackID)
+
+	// Make the member a tech lead of the given team
+	teamMember := &model.TeamMember{
+		GithubTeamID:  team.GithubTeamID,
+		MemberSlackID: member.SlackID,
+	}
+
+	// Fetch team member so we can see its updated tech lead status
+	if err := core.Bot.DAL.GetTeamMember(teamMember); err != nil {
+		log.WithError(err).Errorf("Failed to get team member")
+		return "Failed to get team member", noParams
+	}
+
 	// Update tech lead status
-	member.IsTechLead = !member.IsTechLead
-	if err := core.Bot.DAL.SetMemberIsTechLead(member); err != nil {
-		log.WithError(err).Error("Failed to update %s's tech lead status", username)
-		return "Failed to update tech lead status", noParams
+	teamMember.IsTechLead = !teamMember.IsTechLead
+	if err := core.Bot.DAL.SetIsTechLead(teamMember); err != nil {
+		log.WithError(err).Errorf("Failed to set %s as tech lead of %s",
+			username, teamName)
+		return fmt.Sprintf("Failed to set %s as a tech lead of %s. "+
+			"Make sure %s if part of %s",
+			userMention, teamName, userMention, teamName,
+		), noParams
+	}
+
+	var status string
+	if teamMember.IsTechLead {
+		status = "now"
+	} else {
+		status = "no longer"
 	}
 	return fmt.Sprintf(
-		"Set %s's tech lead status has been set to %t :tada:",
-		cmd.ToMention(member.SlackID), member.IsTechLead,
+		"%s is %s tech lead of %s :tada:", userMention, status, teamName,
 	), noParams
 }

--- a/schema/migrations/7_move_is_tech_lead_to_team_members.sql
+++ b/schema/migrations/7_move_is_tech_lead_to_team_members.sql
@@ -1,0 +1,5 @@
+ALTER TABLE members
+DROP is_tech_lead;
+
+ALTER TABLE team_members
+ADD is_tech_lead BOOLEAN DEFAULT false;

--- a/schema/tables.sql
+++ b/schema/tables.sql
@@ -8,7 +8,6 @@ CREATE TABLE members (
     position TEXT,
     biography TEXT,
     image_url TEXT,
-    is_tech_lead BOOLEAN DEFAULT false,
     is_admin BOOLEAN DEFAULT false,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (now() at time zone 'utc')
 );
@@ -25,5 +24,6 @@ DROP TABLE IF EXISTS team_members CASCADE;
 CREATE TABLE team_members (
     team_github_team_id INTEGER REFERENCES teams(github_team_id) ON DELETE CASCADE,
     member_slack_id TEXT REFERENCES members(slack_id) ON DELETE CASCADE,
+    is_tech_lead BOOLEAN DEFAULT false,
     PRIMARY KEY (team_github_team_id, member_slack_id)
 );


### PR DESCRIPTION
# Changes

* Moved `is_tech_lead` from `members` to `team_members` relation table. Now a member can be a lead of multiple teams and teams can have multiple leads.
* Updated `toggle-tech-leads` and `tech-leads` accordingly.
* Added some handy stuff to the Makefile
* Updated Dockerfile.db so it now places SQL scripts in the DB container so we can easily run migrations from the outside without needing to copy over the scripts each time.
* Made a few other minor improvements to Rocket response meesages