### PR TITLE
Fix team operations

### DIFF
--- a/data/team_test.go
+++ b/data/team_test.go
@@ -1,0 +1,52 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ubclaunchpad/rocket/model"
+)
+
+func TestCreateGetAndDeleteTeam(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	dal, cleanupFunc, err := newTestDBConnection()
+	assert.Nil(t, err)
+	defer cleanupFunc()
+
+	// Create a new team
+	team := &model.Team{
+		Name:         "team-bob",
+		GithubTeamID: 1234,
+		Platform:     "winning",
+		Members: []*model.Member{&model.Member{
+			SlackID:  "1234",
+			Name:     "Little Bruno",
+			Position: "A REAL GUY",
+		}},
+	}
+	err = dal.CreateTeam(team)
+	assert.Nil(t, err)
+
+	// Get team by name
+	teamGetByName := &model.Team{Name: "team-bob"}
+	err = dal.GetTeamByName(teamGetByName)
+	assert.Nil(t, err)
+	assert.Equal(t, team.Platform, teamGetByName.Platform)
+
+	// Get team by ID
+	teamGetByID := &model.Team{GithubTeamID: 1234}
+	err = dal.GetTeamByGithubID(teamGetByID)
+	assert.Nil(t, err)
+	assert.Equal(t, team.Platform, teamGetByID.Platform)
+
+	// Delete team
+	teamDeleteByID := &model.Team{Name: "team-bob"}
+	err = dal.DeleteTeamByName(teamDeleteByID)
+	assert.Nil(t, err)
+
+	// Attempt to get
+	err = dal.GetTeamByGithubID(teamGetByID)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
Opening this PR to investigate issues with the ORM when making team-related queries:

```
Error Trace:	team_test.go:35
Error:      	Expected nil, but got: internal.PGError{m:map[uint8]string{0x56:"ERROR", 0x43:"42703", 0x46:"parse_relation.c", 0x4c:"3293", 0x52:"errorMissingColumn", 0x61:"[::1]:5433", 0x53:"ERROR", 0x4d:"column team_members.member_ does not exist", 0x50:"399"}}
```

Possibly related to https://github.com/ubclaunchpad/rocket/pull/76, where I bumped up our go-pg version since it was woefully outdated and not working properly with newer version of postgres that the new tests were using.