### PR TITLE
Add /api/stats endpoint and github org stats generation

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/ubclaunchpad/rocket/config"
 	"golang.org/x/oauth2"
@@ -16,6 +17,13 @@ type API struct {
 	organization string
 	httpClient   *http.Client
 	*gh.Client
+	cache
+}
+
+type cache struct {
+	validDuration time.Duration
+	statsExpiry   time.Time
+	statsData     *OrgStats
 }
 
 // New creates and returns a GitHub API object based on a configuration object,
@@ -33,7 +41,66 @@ func New(organization string, c *config.Config) *API {
 		organization,
 		tc,
 		client,
+		cache{validDuration: time.Duration(6 * time.Hour)},
 	}
+}
+
+// OrgStats represents basic stats about the configured organization's
+// repositories and activity
+type OrgStats struct {
+	Repositories int            `json:"repositories"`
+	Stargazers   int            `json:"stargazers"`
+	Topics       map[string]int `json:"topics"`
+	Languages    map[string]int `json:"languages"`
+
+	CommitTotal int               `json:"commit_total"`
+	CommitGraph map[time.Time]int `json:"commit_graph"`
+}
+
+// GetOrgStats collects basic stats about the configured organization's
+// repositories and activity
+func (api *API) GetOrgStats() (OrgStats, error) {
+	// Return cache while valid
+	if api.cache.statsExpiry.After(time.Now()) && api.cache.statsData != nil {
+		return *api.cache.statsData, nil
+	}
+
+	// Generate new stats
+	ctx := context.Background()
+	repos, _, err := api.Repositories.ListByOrg(ctx, api.organization, nil)
+	if err != nil {
+		return OrgStats{}, err
+	}
+
+	// Collect stats from repositories
+	stats := OrgStats{
+		Topics:      make(map[string]int),
+		Languages:   make(map[string]int),
+		CommitGraph: make(map[time.Time]int),
+	}
+	for _, r := range repos {
+		// Collect basic repository stats
+		stats.Repositories++
+		stats.Stargazers += r.GetStargazersCount()
+		stats.Languages[r.GetLanguage()]++
+		for _, t := range r.Topics {
+			stats.Topics[t]++
+		}
+
+		// Collect activity stats
+		activity, _, err := api.Repositories.ListCommitActivity(ctx, api.organization, r.GetName())
+		if err != nil {
+			continue
+		}
+		for _, week := range activity {
+			stats.CommitGraph[week.GetWeek().Time] += week.GetTotal()
+		}
+	}
+
+	// Store in cache
+	api.cache.statsExpiry = time.Now().Add(api.cache.validDuration)
+	api.cache.statsData = &stats
+	return stats, nil
 }
 
 // UserExists checks if a given user exists in Github
@@ -106,6 +173,7 @@ func (api *API) GetTeam(id int) (*gh.Team, error) {
 	return nil, fmt.Errorf("GitHub team with ID %d not found", id)
 }
 
+// RemoveTeam removes team with given ID from organization
 func (api *API) RemoveTeam(id int) error {
 	_, err := api.Organizations.DeleteTeam(context.Background(), id)
 	return err

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1,0 +1,58 @@
+package github
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/github"
+)
+
+func TestAPI_GetOrgStats(t *testing.T) {
+	mockOrgStats := OrgStats{
+		Repositories: 100,
+		Topics:       make(map[string]int),
+		Languages:    make(map[string]int),
+		CommitGraph:  make(map[time.Time]int),
+	}
+	type fields struct {
+		organization string
+		httpClient   *http.Client
+		Client       *gh.Client
+		cache        cache
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    OrgStats
+		wantErr bool
+	}{
+		{
+			"should get from cache if not expired",
+			fields{"ubclaunchpad", nil, nil, cache{
+				statsExpiry: time.Now().Add(time.Duration(6 * time.Hour)),
+				statsData:   &mockOrgStats}},
+			mockOrgStats,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &API{
+				organization: tt.fields.organization,
+				httpClient:   tt.fields.httpClient,
+				Client:       tt.fields.Client,
+				cache:        tt.fields.cache,
+			}
+			got, err := api.GetOrgStats()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("API.GetOrgStats() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("API.GetOrgStats() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	// Set up a server listening on the interface specified in the
 	// config. This will panic if the server fails to bind to the interface
 	// or dies for any reason after beginning listening.
-	srv := server.New(cfg, dal, log.WithField("service", "server"))
+	srv := server.New(cfg, dal, gh, log.WithField("service", "server"))
 
 	// Set up the Slack bot. This will create an RTM that receives
 	// events from Slack and respond to them as needed.


### PR DESCRIPTION
I have some things in mind for the website

```go
type OrgStats struct {
	Repositories int            `json:"repositories"`
	Stargazers   int            `json:"stargazers"`
	Topics       map[string]int `json:"topics"`
	Languages    map[string]int `json:"languages"`

	CommitTotal int               `json:"commit_total"`
	CommitGraph map[time.Time]int `json:"commit_graph"`
}
```

Sneak peek:

![image](https://user-images.githubusercontent.com/23356519/43371810-1d0600de-934e-11e8-855b-702b6077ee4a.png)

Pending #87 